### PR TITLE
Makes CoreNLP location configurable

### DIFF
--- a/nlp/utils.py
+++ b/nlp/utils.py
@@ -1,7 +1,7 @@
 from pycorenlp import StanfordCoreNLP
 import os
 
-def annotate_corenlp(text, annotators=['pos'], output_format='json', port=9000):
+def annotate_corenlp(text, annotators=['pos'], output_format='json', hostname='localhost', port=9000):
     """
     Helper function to get the CoreNLP output.
     Usage:
@@ -29,7 +29,7 @@ def annotate_corenlp(text, annotators=['pos'], output_format='json', port=9000):
     text = text.replace("''", '"')
 
     nlp = StanfordCoreNLP('http://{}:{}'.format(
-        os.getenv('CORENLP_HOSTNAME', 'localhost'),
+        os.getenv('CORENLP_HOSTNAME', hostname),
         os.getenv('CORENLP_PORT', port)))
 
     return nlp.annotate(text, properties={

--- a/nlp/utils.py
+++ b/nlp/utils.py
@@ -1,5 +1,5 @@
 from pycorenlp import StanfordCoreNLP
-
+import os
 
 def annotate_corenlp(text, annotators=['pos'], output_format='json', port=9000):
     """
@@ -28,7 +28,10 @@ def annotate_corenlp(text, annotators=['pos'], output_format='json', port=9000):
     # To replace double quotes with single quotes
     text = text.replace("''", '"')
 
-    nlp = StanfordCoreNLP('http://localhost:{}'.format(port))
+    nlp = StanfordCoreNLP('http://{}:{}'.format(
+        os.getenv('CORENLP_HOSTNAME', 'localhost'),
+        os.getenv('CORENLP_PORT', port)))
+
     return nlp.annotate(text, properties={
         'annotators': ','.join(annotators),
         'outputFormat': output_format


### PR DESCRIPTION
Currently the codebase assumes that CoreNLP will be situated on localhost, however, in a microservice architecture this probably isn't true.

This PR populates the hostname and port fields based on environment variables `CORENLP_HOSTNAME` and `CORENLP_PORT`. In their absence, it falls back to defaults `localhost` and `9000`, respectively. 